### PR TITLE
Refactor setEvents, previous and next functions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = true

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 
 <body>
   <div id="dummy"></div>
+
   <!-- Babel -->
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <!-- Jquery -->
@@ -22,7 +23,8 @@
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
     integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
     crossorigin="anonymous"></script>
-  <!-- Plugin -->
+  
+    <!-- Plugin -->
   <script src="src/js/carousel.js"></script>
   <script>
     let options = {

--- a/src/js/carousel.js
+++ b/src/js/carousel.js
@@ -1,149 +1,165 @@
 'use strict';
-$.fn.carousel = function (options) {
 
-  /**
-   * Instance(plugin model).
-   */
-  var instance = {
-    // DOM fields.
-    id: this.attr('id'),
-    root: this,
-    template: null,
-    // Default plugin options.
-    options: {
-      items: [{ 'src': '' }],
-      coverIndex: 0
-    },
-    // Internal options.
-    interval: null,
-    animations: {
-      in: null,
-      out: null
-    }
-  };
+$.fn.carousel = function(options) {
+	/**
+	 * Instance(plugin model).
+	 */
+	var instance = {
+		// DOM fields.
+		id: this.attr('id'),
+		root: this,
+		template: null,
+		// Default plugin options.
+		options: {
+			items: [{ src: '' }],
+			coverIndex: 0
+		},
+		// Internal options.
+		interval: null,
+		animations: {
+			in: null,
+			out: null
+		}
+	};
 
-  /**
-   * Engine.
-   */
-  var run = function () {
-    bootstrapOptions();
-    render();
-  };
+	/**
+	 * Engine.
+	 */
+	const run = () => {
+		bootstrapOptions();
+		render();
+	};
 
-  var bootstrapOptions = function () {
-    // Replace input options in default options.
-    instance.options = $.extend(instance.options, options);
+	const bootstrapOptions = () => {
+		// Replace input options in default options.
+		instance.options = $.extend(instance.options, options);
 
-    // Mode.
-    if (instance.options.mode === 'auto') {
-      play();
-    }
+		// Mode.
+		if (instance.options.mode === 'auto') {
+			play();
+		}
 
-    // Next/previous animations.
-    let currentAnimation = null;
-    switch (instance.options.animation) {
-      case 'slide':
-        currentAnimation = { in: 'slideDown', out: 'slideUp' };
-        break;
-      case 'fade':
-      default:
-        currentAnimation = { in: 'fadeIn', out: 'fadeOut' };
-        break;
-    }
+		// Next/previous animations.
+		let currentAnimation = null;
+		switch (instance.options.animation) {
+			case 'slide':
+				currentAnimation = { in: 'slideDown', out: 'slideUp' };
+				break;
+			case 'fade':
+			default:
+				currentAnimation = { in: 'fadeIn', out: 'fadeOut' };
+				break;
+		}
 
-    // Set instance animation callbacks.
-    instance.animations.in = function () {
-      this[currentAnimation['in']]();
+		// Set instance animation callbacks.
+		instance.animations.in = function() {
+			this[currentAnimation['in']]();
+		};
+		instance.animations.out = function() {
+			return this[currentAnimation['out']]();
+		};
+	};
+
+	const render = () => {
+		const container = $('<div>', { class: 'c-container' });
+		const item = $('<div/>', { id: 'c-item', class: 'c-item' });
+		const img = $('<img/>', {
+			id: 'c-img',
+			class: 'c-img',
+			src: options.items[instance.options.coverIndex].src
+		});
+		const next = $('<div/>', {
+			id: 'c-next',
+			class: 'c-arrow c-next',
+			'data-op': 'next'
+		});
+		const previous = $('<div/>', {
+			id: 'c-previous',
+      class: 'c-arrow c-previous',
+      'data-op': 'previous'
+		});
+
+		item.append(img);
+		instance.template = container.append(item, next, previous);
+
+		setEvents();
+		instance.root.html(instance.template);
+	};
+
+	const setEvents = () => {
+    const tmpl = instance.template;
+    
+    const operation = (op) => {
+      switch (op) {
+        case 'contextmenu': return previous;
+        case 'previous': return previous;
+        case 'click': return next;
+        case 'next': return next;
+        default: return () => {};
+      }
     };
-    instance.animations.out = function () {
-      return this[currentAnimation['out']]();
-    };
-  };
-  
-  var render = function () {
-    let container = $('<div>', { 'class': 'c-container' });
-    let item = $('<div/>', { 'id': 'c-item', 'class': 'c-item' });
-    let img = $('<img/>', { 'id': 'c-img', 'class': 'c-img', 'src': options.items[instance.options.coverIndex].src });
-    let next = $('<div/>', { 'id': 'c-next', 'class': 'c-arrow c-next' });
-    let previous = $('<div/>', { 'id': 'c-previous', 'class': 'c-arrow c-previous' });
-    item.append(img)
-    instance.template = container.append(item, next, previous);;
-    setEvents();
-    instance.root.html(instance.template);
-  };
 
-  var setEvents = function () {
-    // Icons.
-    instance.template.find('#c-next').on('click', function (e) {
-      e.stopPropagation();
-      stop();
-      next();
-    });
-
-    instance.template.find('#c-previous').on('click', function (e) {
-      e.stopPropagation();
-      stop();
-      previous();
-    });
+		// Icons.
+		tmpl.find('#c-next, #c-previous').on('click', function (e) {
+      e.preventDefault();
+			e.stopPropagation();
+			stop();
+      // Must be function instead of lambda because of $(this)
+			operation($(this).data('op'))();
+		});
 
     // Frame.
-    instance.template.on({
-      'click': function () {
-        stop();
-        next();
-      },
-      'contextmenu': function (e) {
-        e.preventDefault();
-        stop();
-        previous();
-      }
+    tmpl.on('click contextmenu', (e) => {
+      e.preventDefault();
+      stop();
+      operation(e.type)();
     });
-  };
+	};
 
-  /**
-   * Animations/Shifting.
-   */
-  var shift = function () {
-    let item = instance.template.find('#c-item');
-    let img = instance.template.find('#c-img');
+	/**
+	 * Animations/Shifting.
+	 */
+	const shift = () => {
+		const tmpl = instance.template;
+		const item = tmpl.find('#c-item');
+		const img = tmpl.find('#c-img');
 
-    // Wait for out animation to stop before working on DOM.
-    // Also wait for next/previous image to be loaded.
-    $.when(instance.animations.out.call(img)).done(function () {
-      img.detach()
-        .attr('src', options.items[instance.options.coverIndex].src)
-        .css({ 'display': 'none' })
-        .one('load', function () {
-          item.append(img);
-          instance.animations.in.call(img);
-        });
-    });
-  };
+		// Wait for out animation to stop before working on DOM.
+		// Also wait for next/previous image to be loaded.
+		$.when(instance.animations.out.call(img)).done(function() {
+			img
+				.detach()
+				.attr('src', options.items[instance.options.coverIndex].src)
+				.css({ display: 'none' })
+				.one('load', function() {
+					item.append(img);
+					instance.animations.in.call(img);
+				});
+		});
+	};
 
-  var next = function () {
-    instance.options.coverIndex = instance.options.coverIndex == instance.options.items.length - 1 ?
-      0 : instance.options.coverIndex + 1;
-    shift();
-  };
+	const next = () => {
+		const opts = instance.options;
+		instance.options.coverIndex =
+			(opts.coverIndex + 1) % (opts.items || []).length;
+		shift();
+	};
 
-  var previous = function () {
-    instance.options.coverIndex = instance.options.coverIndex == 0 ?
-      instance.options.items.length - 1 : instance.options.coverIndex - 1;
-    shift();
-  };
+	const previous = () => {
+		const opts = instance.options;
+		const len = (opts.items || []).length;
+		instance.options.coverIndex = len - ((len - opts.coverIndex) % len) - 1;
+		shift();
+	};
 
-  var play = function () {
-    instance.interval = setInterval(function () {
-      next();
-    }, 3000);
-  };
+	const play = () => {
+		instance.interval = setInterval(() => next(), 3000);
+	};
 
-  var stop = function () {
-    clearTimeout(instance.interval);
-  };
+	const stop = () => clearTimeout(instance.interval);
 
-  /**
-   * Run plugin.
-   */
-  run();
+	/**
+	 * Run plugin.
+	 */
+	run();
 };

--- a/src/js/carousel.js
+++ b/src/js/carousel.js
@@ -75,8 +75,8 @@ $.fn.carousel = function(options) {
 		});
 		const previous = $('<div/>', {
 			id: 'c-previous',
-      class: 'c-arrow c-previous',
-      'data-op': 'previous'
+			class: 'c-arrow c-previous',
+			'data-op': 'previous'
 		});
 
 		item.append(img);
@@ -87,33 +87,38 @@ $.fn.carousel = function(options) {
 	};
 
 	const setEvents = () => {
-    const tmpl = instance.template;
-    
-    const operation = (op) => {
-      switch (op) {
-        case 'contextmenu': return previous;
-        case 'previous': return previous;
-        case 'click': return next;
-        case 'next': return next;
-        default: return () => {};
-      }
-    };
+		const tmpl = instance.template;
+
+		const operation = op => {
+			switch (op) {
+				case 'contextmenu':
+					return previous;
+				case 'previous':
+					return previous;
+				case 'click':
+					return next;
+				case 'next':
+					return next;
+				default:
+					return () => {};
+			}
+		};
 
 		// Icons.
-		tmpl.find('#c-next, #c-previous').on('click', function (e) {
-      e.preventDefault();
+		tmpl.find('#c-next, #c-previous').on('click', function(e) {
+			e.preventDefault();
 			e.stopPropagation();
 			stop();
-      // Must be function instead of lambda because of $(this)
+			// Must be function instead of lambda because of $(this)
 			operation($(this).data('op'))();
 		});
 
-    // Frame.
-    tmpl.on('click contextmenu', (e) => {
-      e.preventDefault();
-      stop();
-      operation(e.type)();
-    });
+		// Frame.
+		tmpl.on('click contextmenu', e => {
+			e.preventDefault();
+			stop();
+			operation(e.type)();
+		});
 	};
 
 	/**


### PR DESCRIPTION
- Change all functions to `const` and used lambdas
- Add editorconfig, with ident size to 2 spaces
- Add operation lambda to map events (click and contextmenu) and operations (previous and next) to respective functions
- Refactor previous and next functions to handle index change using modulus tricks