### PR TITLE
Restructure plugin to be immutable, and expose API

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -13,7 +13,7 @@ parserOptions:
   ecmaVersion: 2018
   sourceType: module
 rules:
-  valid-jsdoc: [warn]
+  valid-jsdoc: [off]
   prettier/prettier: [warn]
   curly: [error, all]
   quotes:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,7 +75,7 @@ const watchFiles = () => {
 
 const js = gulp.series(lint, scripts);
 const build = gulp.series(clean, gulp.parallel(styles, js));
-const watch = gulp.parallel(watchFiles, browserSync);
+const watch = gulp.series(build, gulp.parallel(watchFiles, browserSync));
 
 exports.clean = clean;
 exports.styles = styles;

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
   <!-- Plugin -->
   <script src="dist/carousel.min.js"></script>
   <script>
-    let options = {
+    const options = {
       animation: 'fade',
       auto: false,
       controls: true,
@@ -34,7 +34,7 @@
         { 'src': 'https://cdn.pixabay.com/photo/2015/04/23/22/00/tree-736885__340.jpg' }
       ]
     };
-    $('#dummy').carousel(options);
+    const api = $('#dummy').carousel(options);
   </script>
 </body>
 


### PR DESCRIPTION
Changed all methods to have the API instance as an argument, and then either return a modified instance, or apply a side effect.
Any method with side effects should invoke the `addToHistory` method, which mutates an array with the history of changes to the API instance. We only keep the 10 latest API changes.

The instance API is returned, with the methods `previous`, `next`, `play` and `pause`, which apply a side effect, and return the updated instance, enabling method chaining.

Everything is immutable except the history array with the latest API changes.